### PR TITLE
feat(api): add chronoid/chronoid.h umbrella header

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,12 +327,23 @@ both formats.
 
 ## Layout
 
-Public headers (`chronoid/ksuid.h`, `chronoid/uuidv7.h`) live at
-the top of `chronoid/`; format-specific implementation TUs live in
-per-format subdirectories so the tree advertises the scope at the
-source level. Shared infrastructure (CSPRNG, wipe, byte-order
-helpers) sits at the top of `chronoid/` because it serves every
-format.
+Public headers (`chronoid/chronoid.h`, `chronoid/ksuid.h`,
+`chronoid/uuidv7.h`) live at the top of `chronoid/`; format-specific
+implementation TUs live in per-format subdirectories so the tree
+advertises the scope at the source level. Shared infrastructure
+(CSPRNG, wipe, byte-order helpers) sits at the top of `chronoid/`
+because it serves every format.
+
+For convenience, `<chronoid/chronoid.h>` is an umbrella header that
+pulls in every public surface of libchronoid. Downstream consumers
+that want both formats can write a single include:
+
+```c
+#include <chronoid/chronoid.h>          /* KSUID + UUIDv7 + version */
+```
+
+For TUs that only need one format, prefer the narrower form to keep
+compile units lean:
 
 ```c
 #include <chronoid/ksuid.h>             /* public KSUID API */
@@ -341,12 +352,13 @@ format.
 ```
 
 After install the public headers land at
-`${prefix}/include/chronoid/ksuid.h` and
-`${prefix}/include/chronoid/uuidv7.h`, so downstream consumers use
-the exact same include lines that the in-tree sources do.
+`${prefix}/include/chronoid/{chronoid,ksuid,uuidv7}.h`, so downstream
+consumers use the exact same include lines that the in-tree sources
+do.
 
 ```
 chronoid/
+├── chronoid.h                public umbrella — <chronoid/chronoid.h>
 ├── ksuid.h                   public — <chronoid/ksuid.h>
 ├── uuidv7.h                  public — <chronoid/uuidv7.h>
 ├── chronoid_version.h.in

--- a/chronoid/chronoid.h
+++ b/chronoid/chronoid.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * libchronoid -- C11 toolkit for time-ordered identifiers.
+ *
+ * Umbrella header. Pulls in every public surface of libchronoid so a
+ * downstream consumer can write
+ *
+ *   #include <chronoid/chronoid.h>
+ *
+ * and have access to KSUID, UUIDv7, and the library version macros
+ * without tracking individual format-specific includes. For TUs that
+ * only need one format, prefer the narrower
+ *
+ *   #include <chronoid/ksuid.h>
+ *   #include <chronoid/uuidv7.h>
+ *
+ * to keep compile units lean.
+ *
+ * libchronoid is the successor to segmentio/ksuid's C11 port libksuid
+ * (https://github.com/semantic-reasoning/libksuid, archived). The
+ * KSUID half of this library is wire-compatible with segmentio/ksuid
+ * and inherits libksuid 1.0.0's algorithms verbatim. The UUIDv7 half
+ * is a clean-room implementation per RFC 9562 (May 2024).
+ */
+#ifndef CHRONOID_H
+#define CHRONOID_H
+
+#include <chronoid/chronoid_version.h>
+#include <chronoid/ksuid.h>
+#include <chronoid/uuidv7.h>
+
+#endif /* CHRONOID_H */

--- a/meson.build
+++ b/meson.build
@@ -137,7 +137,9 @@ endif
 # uniformly for in-tree builds, downstream consumers, and the
 # generated install tree (${prefix}/include/chronoid/ksuid.h).
 inc = include_directories('.')
-public_headers = files('chronoid/ksuid.h', 'chronoid/uuidv7.h')
+public_headers = files('chronoid/chronoid.h',
+                       'chronoid/ksuid.h',
+                       'chronoid/uuidv7.h')
 
 # Generate chronoid/chronoid_version.h alongside the source tree's
 # chronoid/. The configure_file lives in chronoid/meson.build so


### PR DESCRIPTION
## Summary

Add `chronoid/chronoid.h`, a thin umbrella header that pulls in every public surface of libchronoid. Downstream consumers who want both formats can write:

```c
#include <chronoid/chronoid.h>
```

instead of tracking individual format-specific includes.

The umbrella does NOT redefine, alias, or extend any API — it's a transitive include of the existing public headers:

```c
#include <chronoid/chronoid_version.h>
#include <chronoid/ksuid.h>
#include <chronoid/uuidv7.h>
```

## Why

A single-format consumer (e.g., a service that only generates KSUIDs) should keep using `<chronoid/ksuid.h>` to keep its compile units lean. The umbrella is for the convenience case where a consumer uses both formats and prefers one include line.

## Scope

- **New file**: `chronoid/chronoid.h` (~30 LOC, SPDX LGPL-3.0-or-later only, guard `CHRONOID_H`).
- **Modified**: `meson.build` (public_headers extended), `README.md` (Layout section documents the umbrella).
- **No** changes to: ksuid.h, uuidv7.h, library source, tests, examples, CLI, version/soversion, license artifacts.

## Verification

- `rm -rf build && meson setup build && meson compile -C build && meson test -C build` → 23/23 OK.
- `DESTDIR=staging meson install -C build` confirms install lays down all three public headers under `${prefix}/include/chronoid/`:
  - `chronoid.h`
  - `chronoid_version.h`
  - `ksuid.h`
  - `uuidv7.h`

## Independent of PR #7

This PR is based on `main` directly (commit `38ae495`), not on `fix/ci-main`. The CI fix work in PR #7 is orthogonal — both PRs can merge in either order.