### PR TITLE
cli: reject -f payload for UUIDv7 (closes #3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once
 
 ## [Unreleased]
 
+### Changed (BREAKING — pre-1.0 contract tightening)
+
+- `chronoid-gen -f payload` is now KSUID-only. Combining `-f payload`
+  with `--format=uuidv7` (generation mode) or with a 36-char
+  UUIDv7 positional (parse mode) exits non-zero with a stderr
+  message pointing at `-f raw` (16-byte image) or `-f inspect`
+  (rand_a / rand_b broken out). Rationale: UUIDv7 has no payload
+  field per RFC 9562 §5.7 — randomness lives in `rand_a` (12 bits)
+  and `rand_b` (62 bits) with version/variant nibbles overlaid, so
+  any single "payload" slice is a category error. The previous
+  10-byte slice shipped in 0.10.0 was structurally invertible but
+  semantically misnamed; failing closed before 1.0.0 keeps the
+  released-API contract honest. The `-f payload` projection for
+  KSUID is unchanged (16 bytes). Closes #3.
+
 ## [0.10.0] — 2026-05-01
 
 ### Added — UUIDv7 support

--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ error rather than a silent coercion.
 `-f raw` emits the unencoded byte image of the ID -- 20 bytes for
 KSUID, 16 bytes for UUIDv7 -- suitable for `> file.bin`.
 
+`-f payload` is KSUID-only. KSUID has a 16-byte payload field
+(`chronoid_ksuid_payload`); UUIDv7 has no equivalent — RFC 9562 §5.7
+splits the random bits across `rand_a` (12 bits) and `rand_b` (62
+bits) with the version and variant nibbles overlaid in the same
+bytes. Combining `-f payload` with `--format=uuidv7` (or with a
+36-char positional that auto-detects as UUIDv7) is a hard error.
+For UUIDv7 use `-f raw` (the 16-byte image) or `-f inspect` (which
+prints `rand_a` and `rand_b` separately).
+
 The full flag set is `--format={ksuid,uuidv7}`, `-n N`,
 `-f {string,inspect,time,timestamp,payload,raw}`, `-v`, `-h`. See
 `chronoid-gen -h` for details.

--- a/examples/chronoid-gen.c
+++ b/examples/chronoid-gen.c
@@ -327,25 +327,15 @@ print_timestamp_uuidv7 (const chronoid_uuidv7_t *id)
   printf ("%" PRId64 "\n", chronoid_uuidv7_unix_ms (id));
 }
 
-/* UUIDv7 has no single "payload" field. We print the random tail
- * (rand_a's 12 bits packed into 2 bytes plus rand_b's 8 bytes) as
- * 10 raw bytes -- analogous to KSUID's binary -f payload output --
- * so scripted callers get a stable, byte-counted rendering. */
-static void
-print_payload_uuidv7 (const chronoid_uuidv7_t *id)
-{
-  uint8_t buf[10];
-  /* rand_a low nibble of byte 6 + byte 7 = 12-bit value packed into
-   * two bytes with the high nibble zeroed. */
-  buf[0] = id->b[6] & 0x0f;
-  buf[1] = id->b[7];
-  /* rand_b -- the variant bits in the top of byte 8 are part of the
-   * raw layout and are emitted as-is; this keeps the output a faithful
-   * slice of the binary UUID for round-trip uses. */
-  memcpy (buf + 2, id->b + 8, 8);
-  set_stdout_binary_for_raw_output ();
-  fwrite (buf, 1, sizeof buf, stdout);
-}
+/* No print_payload_uuidv7: UUIDv7 has no payload field equivalent
+ * to KSUID's 16-byte payload. RFC 9562 §5.7 splits randomness across
+ * rand_a (12 bits) and rand_b (62 bits) with version/variant nibbles
+ * overlaid; any single "payload" projection would be a category
+ * error. Callers wanting the unencoded byte image use -f raw (16
+ * bytes); callers wanting the random fields broken out use
+ * -f inspect (which prints rand_a and rand_b separately). The
+ * `-f payload` combination with --format=uuidv7 is rejected in
+ * main() before any output is written. */
 
 static void
 print_raw_uuidv7 (const chronoid_uuidv7_t *id)
@@ -381,13 +371,13 @@ print_one_uuidv7 (int format, const chronoid_uuidv7_t *id, int verbose)
     case FMT_TIMESTAMP:
       print_timestamp_uuidv7 (id);
       break;
-    case FMT_PAYLOAD:
-      print_payload_uuidv7 (id);
-      break;
     case FMT_RAW:
       print_raw_uuidv7 (id);
       break;
     default:
+      /* FMT_PAYLOAD is rejected up-front in main(); other values are
+       * filtered by parse_format(). Branch exists to satisfy
+       * bugprone-switch-missing-default-case. */
       break;
   }
 }
@@ -400,6 +390,10 @@ usage (FILE *f, const char *argv0)
       "  -n N        number of IDs to generate when no args given (default 1)\n"
       "  -f FORMAT   output projection: one of string, inspect, time,\n"
       "              timestamp, payload, raw (default: string)\n"
+      "              -f payload is KSUID-only; UUIDv7 has no equivalent\n"
+      "              field, so combining -f payload with a UUIDv7 is an\n"
+      "              error. Use -f raw for the 16-byte image or -f inspect\n"
+      "              for rand_a / rand_b.\n"
       "  --format=ID ID format for generation: one of ksuid, uuidv7\n"
       "              (default: ksuid)\n"
       "  -v          prefix each line with the ID and ': '\n"
@@ -502,6 +496,20 @@ main (int argc, char **argv)
     }
   }
 
+  /* Reject the (UUIDv7, -f payload) combination up-front in generation
+   * mode. UUIDv7 has no payload field per RFC 9562 §5.7; rand_a (12
+   * bits) and rand_b (62 bits) live mixed with the version/variant
+   * nibbles across bytes 6..15, and any single-slice "payload"
+   * projection is a category error. The check happens before the
+   * generation loop so no partial output is written. Parse mode runs
+   * the same check per-arg below, after auto-detect. */
+  if (idx == argc && format == FMT_PAYLOAD && idformat == IDFMT_UUIDV7) {
+    fprintf (stderr,
+        "-f payload is not supported for UUIDv7; use -f raw for the\n"
+        "16-byte image or -f inspect for rand_a / rand_b.\n");
+    return 1;
+  }
+
   if (idx == argc) {
     /* Generation mode. */
     for (long i = 0; i < count; ++i) {
@@ -545,6 +553,12 @@ main (int argc, char **argv)
             "format mismatch: --format=%s but %s looks like a %s (%zu chars)\n",
             idformat == IDFMT_UUIDV7 ? "uuidv7" : "ksuid",
             argv[i], detected == IDFMT_UUIDV7 ? "UUIDv7" : "KSUID", len);
+        return 1;
+      }
+      if (format == FMT_PAYLOAD && detected == IDFMT_UUIDV7) {
+        fprintf (stderr,
+            "-f payload is not supported for UUIDv7; use -f raw for the\n"
+            "16-byte image or -f inspect for rand_a / rand_b.\n");
         return 1;
       }
       if (detected == IDFMT_UUIDV7) {

--- a/tests/test_cli.sh
+++ b/tests/test_cli.sh
@@ -229,4 +229,60 @@ if "$KSUID_GEN" --format=wat >/dev/null 2>&1; then
   exit 1
 fi
 
+# 20. -f payload rejected for UUIDv7 in generation mode (no payload
+#     field per RFC 9562; rejection must happen before any output is
+#     written so scripted callers don't see a partial stream).
+gen_pl_out=$("$KSUID_GEN" --format=uuidv7 -f payload 2>/dev/null || true)
+if [ -n "$gen_pl_out" ]; then
+  echo "expected empty stdout for -f payload + uuidv7 rejection, got: $gen_pl_out" >&2
+  exit 1
+fi
+gen_pl_err=$("$KSUID_GEN" --format=uuidv7 -f payload 2>&1 >/dev/null || true)
+case "$gen_pl_err" in
+  *"-f payload is not supported for UUIDv7"*) ;;
+  *)
+    echo "expected literal '-f payload is not supported for UUIDv7' in stderr, got: $gen_pl_err" >&2
+    exit 1
+    ;;
+esac
+if "$KSUID_GEN" --format=uuidv7 -f payload >/dev/null 2>&1; then
+  echo "expected non-zero exit for -f payload + --format=uuidv7" >&2
+  exit 1
+fi
+# The verbose flag (-v) must not bypass the rejection: -v is parsed
+# the same way as any other option, but the rejection happens up-front
+# in main() before any per-id printing, so this exercise pins that
+# code-flow guarantee.
+if "$KSUID_GEN" -v --format=uuidv7 -f payload >/dev/null 2>&1; then
+  echo "expected non-zero exit for -v --format=uuidv7 -f payload" >&2
+  exit 1
+fi
+
+# 21. -f payload rejected for UUIDv7 in parse mode (auto-detected by
+#     the 36-char positional length).
+if "$KSUID_GEN" -f payload "$RFC_UUIDV7" >/dev/null 2>&1; then
+  echo "expected non-zero exit for -f payload on uuidv7 positional" >&2
+  exit 1
+fi
+parse_pl_err=$("$KSUID_GEN" -f payload "$RFC_UUIDV7" 2>&1 >/dev/null || true)
+case "$parse_pl_err" in
+  *"-f payload is not supported for UUIDv7"*) ;;
+  *)
+    echo "expected literal '-f payload is not supported for UUIDv7' in stderr (parse mode), got: $parse_pl_err" >&2
+    exit 1
+    ;;
+esac
+
+# 22. -h text advertises the KSUID-only restriction so the user-facing
+#     contract is discoverable without reading the source.
+help_text=$("$KSUID_GEN" -h 2>&1)
+case "$help_text" in
+  *"-f payload is KSUID-only"*) ;;
+  *)
+    echo "expected -h text to advertise '-f payload is KSUID-only', got:" >&2
+    printf '%s\n' "$help_text" >&2
+    exit 1
+    ;;
+esac
+
 echo "chronoid-gen integration: all checks passed"


### PR DESCRIPTION
## Summary

- Reject `chronoid-gen -f payload` when combined with UUIDv7 (either `--format=uuidv7` in generation mode, or a 36-char positional auto-detected as UUIDv7 in parse mode).
- KSUID `-f payload` is unchanged (still emits 16 bytes).
- Update `-h` text, `README.md`, and `CHANGELOG.md` `[Unreleased]` (BREAKING — pre-1.0 contract tightening).

## Why

UUIDv7 has no payload field equivalent to KSUID's 16-byte payload field. RFC 9562 §5.7 splits randomness across `rand_a` (12 bits) and `rand_b` (62 bits) with version/variant nibbles overlaid in the same bytes. Any single-slice "payload" projection is a category error. The prior 10-byte slice shipped in 0.10.0 was structurally invertible but semantically misnamed; failing closed before 1.0.0 keeps the released-API contract honest.

For UUIDv7 callers: `-f raw` (16-byte image) and `-f inspect` (rand_a / rand_b broken out) cover the use cases the rejected projection only approximated.

## Test plan

- [x] `meson test -C build` — 23/23 tests pass locally.
- [x] New tests in `tests/test_cli.sh`:
  - generation-mode rejection (empty stdout, literal stderr, non-zero exit)
  - generation-mode rejection with `-v` verbose flag
  - parse-mode rejection on a UUIDv7 positional
  - `-h` text advertises the KSUID-only restriction
- [x] KSUID `-f payload` still emits 16 bytes (existing test #8 still green).
- [x] `tools/gst-indent` clean on `examples/chronoid-gen.c`.
- [x] CHANGELOG `[0.10.0]` block untouched; new entry only under `[Unreleased]`.

Closes #3