### PR TITLE
docs: clarify chronoid_set_rand thread-safety contract (closes #5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once
   released-API contract honest. The `-f payload` projection for
   KSUID is unchanged (16 bytes). Closes #3.
 
+### Changed (docs-only — no behavior change)
+
+- Clarify the thread-safety contract for `chronoid_set_rand` in
+  `chronoid/ksuid.h`: the override is held in two independent atomic
+  pointers (one for `fn`, one for `ctx`), not a single atomic pair,
+  so a draw racing a swap can observe a crossed `(old_fn, new_ctx)`
+  pairing. Callers must quiesce all in-flight
+  `chronoid_ksuid_new` / `chronoid_uuidv7_new` calls before swapping
+  the override or freeing `ctx`. Cross-referenced from the UUIDv7
+  generation prose in `chronoid/uuidv7.h`. No ABI change. Closes #5.
+
 ## [0.10.0] — 2026-05-01
 
 ### Added — UUIDv7 support

--- a/chronoid/ksuid.h
+++ b/chronoid/ksuid.h
@@ -258,13 +258,34 @@ extern "C"
 
 /* Replace the global random source. The default source is the
  * per-thread ChaCha20 CSPRNG; calling this with a non-NULL |fn|
- * routes chronoid_ksuid_new through |fn(ctx, buf, n)| instead. |fn| must
- * return 0 on success and non-zero on failure. Passing NULL restores
- * the default source.
+ * routes chronoid_ksuid_new -- and chronoid_uuidv7_new, which shares
+ * the same override slot -- through |fn(ctx, buf, n)| instead. |fn|
+ * must return 0 on success and non-zero on failure. Passing NULL for
+ * |fn| restores the default source.
  *
- * The override is global and atomic-pointer-protected, so swapping
- * mid-flight is race-free; however, |fn| itself MUST be thread-safe
- * if multiple threads will call chronoid_ksuid_new concurrently. */
+ * Thread-safety contract. The override is held in two independent
+ * atomic pointers (one for |fn|, one for |ctx|), each loaded with
+ * acquire ordering on every draw and stored with release ordering by
+ * chronoid_set_rand. Each pointer in isolation therefore loads as a
+ * coherent value -- never garbage -- and the swap is process-global.
+ * The (fn, ctx) pair is NOT a single atomic snapshot, however: a
+ * draw racing a swap from (old_fn, old_ctx) to (new_fn, new_ctx)
+ * can observe a crossed pairing such as (old_fn, new_ctx), with the
+ * old hook being invoked against the new context's data. Callers
+ * that need to change |fn| and |ctx| together MUST quiesce all
+ * in-flight chronoid_ksuid_new / chronoid_uuidv7_new calls before
+ * swapping (the install-once-at-process-start pattern is the easiest
+ * way to honour this).
+ *
+ * |fn| itself MUST be thread-safe if multiple threads will call
+ * chronoid_ksuid_new or chronoid_uuidv7_new concurrently while the
+ * override is installed.
+ *
+ * The lifetime of |ctx| MUST exceed every draw that could still be
+ * holding it. To free |ctx| safely, install a different |fn| (or
+ * NULL) via chronoid_set_rand, then quiesce all generator threads
+ * (or wait for every started draw to return) before releasing the
+ * storage. */
   typedef int (*chronoid_rng_fn) (void *ctx, uint8_t * buf, size_t n);
   CHRONOID_PUBLIC void chronoid_set_rand (chronoid_rng_fn fn, void *ctx);
 

--- a/chronoid/uuidv7.h
+++ b/chronoid/uuidv7.h
@@ -218,9 +218,12 @@ extern "C"
  * the OS entropy source (getrandom on Linux, getentropy on macOS,
  * BCryptGenRandom on Windows). The same chronoid_set_rand override
  * registered for KSUID generation also routes UUIDv7 random draws --
- * one global CSPRNG hookup serves both formats. On entropy-source
- * failure the function returns CHRONOID_UUIDV7_ERR_RNG and leaves
- * |*out| untouched.
+ * one global CSPRNG hookup serves both formats. See the full
+ * thread-safety contract for chronoid_set_rand in chronoid/ksuid.h
+ * (the (fn, ctx) pair is NOT a single atomic snapshot, so callers
+ * must quiesce in-flight draws before swapping the override or
+ * freeing |ctx|). On entropy-source failure the function returns
+ * CHRONOID_UUIDV7_ERR_RNG and leaves |*out| untouched.
  * -------------------------------------------------------------------------- */
 
 /* Generate a new UUIDv7 stamped with the current wall-clock time. Each


### PR DESCRIPTION
## Summary

- Replace the `chronoid_set_rand` docstring in `chronoid/ksuid.h` to spell out the full thread-safety contract: the override is two independent atomic pointers (not a single atomic snapshot), so a draw racing a swap can observe the crossed `(old_fn, new_ctx)` pairing.
- Document the obligations: per-pointer atomicity, fn-thread-safety under concurrent `chronoid_ksuid_new` / `chronoid_uuidv7_new`, and the ctx-lifetime / quiesce-before-free protocol.
- Add a one-sentence cross-reference in `chronoid/uuidv7.h` so a UUIDv7-only reader gets pointed at the full contract without duplicating it.
- Add a `### Changed (docs-only — no behavior change)` entry to `[Unreleased]` in CHANGELOG.

Documentation only. No ABI, behaviour, or symbol changes.

## Why

The previous docstring said the slot was "atomic-pointer-protected, race-free" — technically true per pointer but materially misleading about the `(fn, ctx)` tuple. A naive caller could install a new override, free the old `ctx`, and observe undefined behaviour from in-flight draws still dereferencing the old pointer. The implementation in `chronoid/ksuid/ksuid.c:115-153` already acknowledges this internally; the public docstring now matches that reality.

## Test plan

- [x] `meson compile -C build` — clean build.
- [x] `meson test -C build` — 23/23 tests pass.
- [x] `tools/gst-indent chronoid/ksuid.h chronoid/uuidv7.h` — zero post-format drift.
- [x] `git diff main..HEAD` — touches only `chronoid/ksuid.h`, `chronoid/uuidv7.h`, `CHANGELOG.md`. No `.c` file changes.
- [x] CHANGELOG `[0.10.0]` block untouched; new entry only under `[Unreleased]`.

## Follow-up (separately tracked)

A multi-thread regression test that exercises the documented contract (concurrent draws while a quiesce-then-swap pattern installs a new override, asserting no torn pairings under TSan) would lock the contract in code. Not bundled here to keep the commit docs-only.

Closes #5