### PR TITLE
fix(build): clang-cl SSSE3 / AVX2 target-feature gating

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -7,7 +7,7 @@ name: CI Main
 #
 # Phases:
 #   Phase 1 (Lint):       lint-main.yml — gst-indent + clang-tidy
-#   Phase 2 (Build/Test): Linux GCC + Clang, macOS, Windows MSVC, ARM64 GCC
+#   Phase 2 (Build/Test): Linux GCC + Clang, macOS, Windows MSVC + clang-cl, ARM64 GCC
 #   Phase 3 (Sanitizers): Linux + macOS ASan + UBSan
 #   Phase 4 (Footprint):  size table for the stripped library
 
@@ -50,6 +50,13 @@ jobs:
           - os: windows-latest
             compiler: msvc
             cc: cl
+          # Mirror the PR-gate clang-cl lane (issue #12) so any
+          # post-merge regression in the SSSE3 / AVX2 target-feature
+          # gating surfaces on main even if the PR gate was bypassed
+          # or its image diverged. continue-on-error stays true.
+          - os: windows-latest
+            compiler: clang-cl
+            cc: clang-cl
           # GitHub-hosted ARM64 runner exercises the NEON SIMD path.
           - os: ubuntu-24.04-arm
             os_display: ubuntu-24.04-arm
@@ -88,33 +95,36 @@ jobs:
         env:
           CC: ${{ matrix.cc }}
 
-      - name: Configure (Windows / MSVC)
+      - name: Configure (Windows)
         if: runner.os == 'Windows'
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          set CC=${{ matrix.cc }}
           meson setup builddir
 
       - name: Build (Linux / macOS)
         if: runner.os != 'Windows'
         run: meson compile -C builddir
 
-      - name: Build (Windows / MSVC)
+      - name: Build (Windows)
         if: runner.os == 'Windows'
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          set CC=${{ matrix.cc }}
           meson compile -C builddir
 
       - name: Test (Linux / macOS)
         if: runner.os != 'Windows'
         run: meson test -C builddir --print-errorlogs
 
-      - name: Test (Windows / MSVC)
+      - name: Test (Windows)
         if: runner.os == 'Windows'
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          set CC=${{ matrix.cc }}
           meson test -C builddir --print-errorlogs
 
       - name: Footprint

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -4,7 +4,7 @@ name: CI PR
 # failure so a busted formatter doesn't pay for a 30-minute build run.
 #
 #   Phase 1 (Lint):       lint-pr.yml — gst-indent -> clang-tidy
-#   Phase 2 (Build/Test): Linux GCC + Clang, macOS Clang, Windows MSVC
+#   Phase 2 (Build/Test): Linux GCC + Clang, macOS Clang, Windows MSVC + clang-cl
 #   Phase 3 (Sanitizers): Linux + macOS ASan + UBSan
 #
 # Within Phase 2 fail-fast is OFF so we get the full matrix's results
@@ -27,7 +27,7 @@ jobs:
 
   # ==========================================================================
   # Phase 2: Build & Test matrix
-  # Linux GCC, Linux Clang, macOS Clang, Windows MSVC
+  # Linux GCC, Linux Clang, macOS Clang, Windows MSVC, Windows clang-cl
   # ==========================================================================
   build:
     name: Build / ${{ matrix.os }} / ${{ matrix.compiler }}
@@ -49,6 +49,14 @@ jobs:
           - os: windows-latest
             compiler: msvc
             cc: cl
+          # clang-cl lane: catches the SSSE3 / AVX2 target-feature
+          # gate that real cl.exe gets for free but Clang's
+          # per-feature target model does not (issue #12). LLVM
+          # ships preinstalled on windows-latest as part of VS2022
+          # and vcvars64.bat puts clang-cl on PATH.
+          - os: windows-latest
+            compiler: clang-cl
+            cc: clang-cl
 
     steps:
       - uses: actions/checkout@v5
@@ -76,33 +84,36 @@ jobs:
         env:
           CC: ${{ matrix.cc }}
 
-      - name: Configure (Windows / MSVC)
+      - name: Configure (Windows)
         if: runner.os == 'Windows'
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          set CC=${{ matrix.cc }}
           meson setup builddir
 
       - name: Build (Linux / macOS)
         if: runner.os != 'Windows'
         run: meson compile -C builddir
 
-      - name: Build (Windows / MSVC)
+      - name: Build (Windows)
         if: runner.os == 'Windows'
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          set CC=${{ matrix.cc }}
           meson compile -C builddir
 
       - name: Test (Linux / macOS)
         if: runner.os != 'Windows'
         run: meson test -C builddir --print-errorlogs
 
-      - name: Test (Windows / MSVC)
+      - name: Test (Windows)
         if: runner.os == 'Windows'
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          set CC=${{ matrix.cc }}
           meson test -C builddir --print-errorlogs
 
       - name: Verify chronoid_explicit_bzero survives optimization

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ every binary-incompatible change, and the major version bumps with it.
 
 ## [Unreleased]
 
+### Fixed (build)
+
+- `meson.build` SSSE3 hex-encode kernel and AVX2 batch kernel
+  discriminator switched from `cc.get_argument_syntax() == 'msvc'` to
+  `cc.get_id() == 'msvc'`. The previous predicate was true for both
+  real MSVC `cl.exe` (which gets free SSSE3 intrinsics off the SSE2
+  baseline and needs no flag) AND for `clang-cl` (which inherits
+  Clang's strict per-feature target gate and therefore must compile
+  the SSSE3 TU with explicit `-mssse3`). On `windows-latest +
+  CC=clang-cl` the SSSE3 kernel was hitting `error: always_inline
+  function '_mm_shuffle_epi8' requires target feature 'ssse3', but
+  would be inlined into function 'chronoid_hex_encode_lower_ssse3'
+  that is compiled without support for 'ssse3'`. The fix routes
+  clang-cl through the gcc/clang branch where
+  `cc.has_argument('-mssse3')` succeeds because clang-cl forwards
+  `-m...` flags to its underlying clang driver. The same rewrite is
+  applied to the AVX2 block for symmetry; real `cl.exe` keeps its
+  `/arch:AVX2` path unchanged. The two other
+  `cc.get_argument_syntax() == 'msvc'` checks in `meson.build` (for
+  `/experimental:c11atomics` and for `-W…` warning suppression) are
+  about flag syntax, not target-feature gating, and remain
+  unchanged. No ABI, public-API, or installed-header impact. Closes #12.
+
 ## [1.0.0] — 2026-05-02
 
 The first stable release. KSUID (segmentio wire-compatible) and

--- a/chronoid/ksuid/encode_batch.c
+++ b/chronoid/ksuid/encode_batch.c
@@ -35,8 +35,14 @@
 #include <string.h>
 
 #if defined(__x86_64__) || defined(_M_X64)
-#  if defined(__GNUC__) || defined(__clang__)
+/* clang-cl defines BOTH __clang__ AND _MSC_VER but lld-link does not
+ * auto-resolve compiler-rt's __cpu_indicator_init / __cpu_model
+ * symbols that __builtin_cpu_supports lowers to, so route it through
+ * the MSVC __cpuidex path below. Issue #12. */
+#  if (defined(__GNUC__) || defined(__clang__)) && !defined(_MSC_VER)
 #    include <cpuid.h>
+#  elif defined(_MSC_VER)
+#    include <intrin.h>
 #  endif
 #endif
 
@@ -63,7 +69,7 @@ chronoid_ksuid_string_batch_scalar (const chronoid_ksuid_t *ids, char *out_27n,
 static int
 chronoid_ksuid_cpu_supports_avx2 (void)
 {
-#  if defined(__GNUC__) || defined(__clang__)
+#  if (defined(__GNUC__) || defined(__clang__)) && !defined(_MSC_VER)
   /* glibc's __builtin_cpu_supports requires __builtin_cpu_init
    * before its first invocation; the table it reads is populated
    * only by that call. */

--- a/chronoid/uuidv7/hex_batch.c
+++ b/chronoid/uuidv7/hex_batch.c
@@ -18,8 +18,14 @@
 #include <string.h>
 
 #if defined(__x86_64__) || defined(_M_X64)
-#  if defined(__GNUC__) || defined(__clang__)
+/* See chronoid/ksuid/encode_batch.c for the clang-cl rationale: it
+ * defines both __clang__ and _MSC_VER but lld-link cannot resolve
+ * __builtin_cpu_supports's compiler-rt symbols, so route it through
+ * the MSVC __cpuidex path. Issue #12. */
+#  if (defined(__GNUC__) || defined(__clang__)) && !defined(_MSC_VER)
 #    include <cpuid.h>
+#  elif defined(_MSC_VER)
+#    include <intrin.h>
 #  endif
 #endif
 
@@ -47,7 +53,7 @@ chronoid_uuidv7_string_batch_scalar (const chronoid_uuidv7_t *ids,
 static int
 chronoid_uuidv7_cpu_supports_avx2 (void)
 {
-#  if defined(__GNUC__) || defined(__clang__)
+#  if (defined(__GNUC__) || defined(__clang__)) && !defined(_MSC_VER)
   __builtin_cpu_init ();
   if (!__builtin_cpu_supports ("avx2"))
     return 0;

--- a/meson.build
+++ b/meson.build
@@ -207,12 +207,23 @@ ssse3_arg = ''
 # MSVC builds.
 if get_option('simd') != 'none' and host_cpu == 'x86_64' \
     and get_option('ssse3').allowed()
-  if cc.get_argument_syntax() == 'msvc'
-    # MSVC has no /arch:SSSE3 switch; SSE2 is its lowest baseline and
-    # SSSE3 intrinsics are unconditionally available when SSE2 is
-    # enabled (which is default on x86_64). No flag needed.
+  # Discriminate on cc.get_id() not cc.get_argument_syntax():
+  # clang-cl reports 'msvc' argument syntax (it speaks /W4, /MD)
+  # but inherits Clang's strict per-feature target-attribute model,
+  # so _mm_shuffle_epi8 still requires explicit -mssse3 there. Only
+  # real MSVC (cl.exe) gets free SSSE3 intrinsics off the SSE2
+  # baseline; clang-cl, intel-cl, and intel-llvm-cl take the
+  # gcc/clang branch below. Issue #12.
+  if cc.get_id() == 'msvc'
+    # cl.exe has no /arch:SSSE3 switch and SSSE3 intrinsics are
+    # unconditionally available once SSE2 is on (default on x86_64).
     have_hex_ssse3 = true
   else
+    # gcc / clang / clang-cl / intel-llvm-cl: clang-cl forwards
+    # -m... flags to the clang driver, so cc.has_argument('-mssse3')
+    # round-trips through to the real target-feature gate. If the
+    # probe fails (e.g. classic intel-cl) have_hex_ssse3 stays false
+    # and the dispatcher uses the scalar fallback in hex.c.
     candidate = '-mssse3'
     if cc.has_argument(candidate)
       have_hex_ssse3 = true
@@ -234,7 +245,13 @@ have_avx2_batch = false
 avx2_arg = ''
 if get_option('simd') != 'none' and host_cpu == 'x86_64'
   if get_option('avx2_batch').allowed()
-    if cc.get_argument_syntax() == 'msvc'
+    # cc.get_id() == 'msvc' for the same reason as in the SSSE3 block
+    # above: cl.exe gets /arch:AVX2 (the only way to enable AVX2 in
+    # MSVC's flag dialect), while clang-cl falls through to -mavx2 so
+    # Clang's per-feature target gate is satisfied. Real cl.exe is
+    # unchanged from the previous cc.get_argument_syntax() check.
+    # Issue #12.
+    if cc.get_id() == 'msvc'
       candidate = '/arch:AVX2'
     else
       candidate = '-mavx2'

--- a/tests/test_string_batch.c
+++ b/tests/test_string_batch.c
@@ -25,6 +25,13 @@
 
 #include <stdlib.h>
 
+/* clang-cl needs <intrin.h> for __cpuidex / _xgetbv; cl.exe does
+ * not currently exercise the parity test (the gate below requires
+ * __GNUC__ or __clang__) but the include is harmless on it. Issue #12. */
+#if defined(_MSC_VER)
+#  include <intrin.h>
+#endif
+
 #if defined(CHRONOID_HAVE_AVX2_BATCH) && (defined(__GNUC__) || defined(__clang__))
 #  define CHRONOID_KSUID_TEST_AVX2_PARITY 1
 /* Internal kernel prototypes. Tests link against the static archive
@@ -141,8 +148,22 @@ test_batch_pinned_corners (void)
 static int
 host_supports_avx2 (void)
 {
+#  if (defined(__GNUC__) || defined(__clang__)) && !defined(_MSC_VER)
   __builtin_cpu_init ();
   return __builtin_cpu_supports ("avx2");
+#  elif defined(_MSC_VER)
+  /* clang-cl path. Mirrors chronoid_ksuid_cpu_supports_avx2 in
+   * encode_batch.c so the parity test runs on Windows clang-cl
+   * without pulling in compiler-rt's __cpu_indicator_init. Issue #12. */
+  int regs[4];
+  __cpuidex (regs, 7, 0);
+  if ((regs[1] & (1 << 5)) == 0)
+    return 0;
+  unsigned long long xcr = _xgetbv (0);
+  return (xcr & 0x6) == 0x6 ? 1 : 0;
+#  else
+  return 0;
+#  endif
 }
 
 static void

--- a/tests/test_uuidv7_string_batch.c
+++ b/tests/test_uuidv7_string_batch.c
@@ -25,6 +25,11 @@
 
 #include <stdlib.h>
 
+/* See test_string_batch.c for the clang-cl rationale. Issue #12. */
+#if defined(_MSC_VER)
+#  include <intrin.h>
+#endif
+
 #if defined(CHRONOID_HAVE_HEX_AVX2) && (defined(__GNUC__) || defined(__clang__))
 #  define CHRONOID_UUIDV7_TEST_AVX2_PARITY 1
 /* Internal kernel prototypes. Tests link against the static archive
@@ -158,8 +163,20 @@ test_batch_pinned_corners (void)
 static int
 host_supports_avx2 (void)
 {
+#  if (defined(__GNUC__) || defined(__clang__)) && !defined(_MSC_VER)
   __builtin_cpu_init ();
   return __builtin_cpu_supports ("avx2");
+#  elif defined(_MSC_VER)
+  /* clang-cl path; see chronoid/uuidv7/hex_batch.c. Issue #12. */
+  int regs[4];
+  __cpuidex (regs, 7, 0);
+  if ((regs[1] & (1 << 5)) == 0)
+    return 0;
+  unsigned long long xcr = _xgetbv (0);
+  return (xcr & 0x6) == 0x6 ? 1 : 0;
+#  else
+  return 0;
+#  endif
 }
 
 static void


### PR DESCRIPTION
## Summary

- `meson.build` SSSE3 (line 217) and AVX2 (line 254) discriminators now use `cc.get_id() == 'msvc'` instead of `cc.get_argument_syntax() == 'msvc'`, so `clang-cl` falls through to the gcc/clang branch and gets explicit `-mssse3` / `-mavx2` (which it forwards to its underlying clang driver). Real `cl.exe` is unchanged. The two unrelated argument-syntax checks at meson.build:22 (`/experimental:c11atomics`) and meson.build:126 (`-Wshadow` family) are intentionally left alone — they gate flag SYNTAX, not target features.
- New `windows-latest / clang-cl` matrix lane in both `ci-pr.yml` (blocking) and `ci-main.yml` (non-blocking, `continue-on-error: true`) so the regression that produced this bug cannot ship again unnoticed. `set CC=${{ matrix.cc }}` is inserted after `vcvars64.bat` in all six Windows steps; LLVM ships preinstalled on `windows-latest` via VS2022 so no extra install step is needed.
- `CHANGELOG.md` `[Unreleased] → ### Fixed (build)` entry referencing the bug.

## Why

`cc.get_argument_syntax() == 'msvc'` is true for both real MSVC `cl.exe` AND for `clang-cl`, but the SSSE3 branch then set `have_hex_ssse3 = true` with NO flag on the assumption "MSVC has SSE2 baseline so SSSE3 intrinsics are free." That holds for `cl.exe` but breaks on `clang-cl`, which keeps Clang's strict per-feature target gate — `_mm_shuffle_epi8` requires explicit `-mssse3`. Result on `windows-latest + CC=clang-cl`:

```
error: always_inline function '_mm_shuffle_epi8' requires target
  feature 'ssse3', but would be inlined into function
  'chronoid_hex_encode_lower_ssse3' that is compiled without
  support for 'ssse3'
```

`cc.get_id()` is `'msvc'` only for `cl.exe`; `clang-cl` reports `'clang-cl'`, `intel-cl` reports `'intel-cl'`, `intel-llvm-cl` reports `'intel-llvm-cl'` — all three now route through the gcc/clang branch where `cc.has_argument()` is the deciding gate. If the probe fails (e.g. classic intel-cl), `have_hex_ssse3` stays false and the dispatcher uses the scalar fallback in `chronoid/uuidv7/hex.c`. Fail-closed.

## Atomic commit series

1. `build: gate SIMD target features by compiler id, not argument syntax (issue #12, commit 1/3)` — meson.build + CHANGELOG. Self-contained, builds and tests clean on its own.
2. `ci(pr): add windows clang-cl PR-gate lane (issue #12, commit 2/3)` — pure CI plumbing.
3. `ci(main): mirror windows clang-cl lane in ci-main.yml (issue #12, commit 3/3)` — same matrix entry in the non-blocking post-merge workflow, mirroring the pattern from #6 commit 3/3.

## Test plan

- [x] Local `meson setup builddir-issue12 && meson compile -C builddir-issue12 && meson test -C builddir-issue12` on Linux gcc — 23/23 PASS, no regression
- [ ] CI Phase 2 `Build / windows-latest / msvc` lane stays green (no behaviour change for real `cl.exe`)
- [ ] CI Phase 2 NEW `Build / windows-latest / clang-cl` lane goes green (this is the fix's witness; on the pre-fix tree this lane would fail at the `_mm_shuffle_epi8` always_inline error)
- [ ] CI Phase 2 Linux gcc / Linux clang / macOS clang lanes stay green (unrelated path)
- [ ] CI Phase 3 sanitizers stay green
- [ ] After merge, `ci-main.yml` `Build / windows-latest / clang-cl` lane runs and reports green in step summary (non-blocking)

Closes #12