### PR TITLE
[codex] Bump libchronoid soversion to 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ primitives.
 
 **1.0.0 — stable.** First committed ABI. KSUID (segmentio
 wire-compatible) and UUIDv7 (RFC 9562) surfaces are both
-feature-complete, tested, and locked at `libchronoid.so.0`. SemVer
+feature-complete, tested, and locked at `libchronoid.so.1`. SemVer
 applies in full from 1.0.0 forward: additions bump the minor;
 removals or signature changes require a SONAME bump
-(`libchronoid.so.0` → `libchronoid.so.1`) and a new major version.
+(`libchronoid.so.1` → `libchronoid.so.2`) and a new major version.
 Distros, language bindings, and downstream consumers can pin
 against `libchronoid >= 1.0.0` and rely on the documented contract.
 
@@ -31,7 +31,7 @@ guarantees for KSUID. The rename reflects an enlarged scope: a
 single-format port grows into a multi-format toolkit. The KSUID public
 API (types, constants, functions) is unchanged byte-for-byte at the
 ABI level; only header path (`<chronoid/ksuid.h>` instead of
-`<libksuid/ksuid.h>`) and library/SONAME (`libchronoid.so.0` instead
+`<libksuid/ksuid.h>`) and library/SONAME (`libchronoid.so.1` instead
 of `libksuid.so.1`) move.
 
 ## Goals

--- a/meson.build
+++ b/meson.build
@@ -342,7 +342,7 @@ chronoid_lib = both_libraries('chronoid', core_sources,
   # soversion tracks semver major: a major bump means a binary-
   # incompatible ABI break and the SONAME flips with it. 1.0 is the
   # first stable ABI commitment.
-  soversion           : '0',
+  soversion           : '1',
   install             : true,
 )
 


### PR DESCRIPTION
## Summary

- Set the Meson shared-library `soversion` from `0` to `1`, so generated shared-library metadata uses `libchronoid.so.1` / `libchronoid.1.dylib`.
- Update README SONAME references and the documented next incompatible bump example to match the new ABI version.

## Why

The build was still emitting shared-library version `0` even though the intended ABI SONAME is `1`. This aligns the build configuration and user-facing documentation.

## Validation

- `meson setup build --wipe`
- `meson compile -C build`
- `meson test -C build` (`22/22 OK`)
- Verified macOS output: `build/libchronoid.1.dylib` with install name `@rpath/libchronoid.1.dylib`.
