### PR TITLE
Release 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,26 @@ All notable changes to libchronoid are recorded here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and versions
 follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 1.0.0 is the first stable ABI commitment; from this point forward a
-SONAME bump (`libchronoid.so.0` → `libchronoid.so.1`) accompanies
+SONAME bump (`libchronoid.so.1` → `libchronoid.so.2`) accompanies
 every binary-incompatible change, and the major version bumps with it.
 
 ## [Unreleased]
+
+## [1.0.2] — 2026-05-15
+
+Patch release correcting the 1.0 branch shared-library SONAME to
+`libchronoid.so.1`. The Meson `soversion` setting was still `0`, so
+shared builds could emit `libchronoid.so.0` despite the 1.0 stable
+ABI commitment and existing footprint documentation using
+`libchronoid.so.1.0.0`.
+
+### Fixed (build)
+
+- `meson.build` now sets `soversion : '1'`, producing
+  `libchronoid.so.1` on ELF platforms and `libchronoid.1.dylib` on
+  macOS.
+- README SONAME references now consistently describe the 1.0 branch
+  ABI as `libchronoid.so.1`.
 
 ## [1.0.1] — 2026-05-02
 
@@ -382,7 +398,8 @@ top of this base.
 - `chronoid-gen` (formerly `ksuid-gen`) CLI for round-trip generation
   and inspection.
 
-[Unreleased]: https://github.com/semantic-reasoning/libchronoid/compare/v1.0.1...HEAD
+[Unreleased]: https://github.com/semantic-reasoning/libchronoid/compare/v1.0.2...HEAD
+[1.0.2]: https://github.com/semantic-reasoning/libchronoid/releases/tag/v1.0.2
 [1.0.1]: https://github.com/semantic-reasoning/libchronoid/releases/tag/v1.0.1
 [1.0.0]: https://github.com/semantic-reasoning/libchronoid/releases/tag/v1.0.0
 [0.10.1]: https://github.com/semantic-reasoning/libchronoid/releases/tag/v0.10.1

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ primitives.
 
 **1.0.0 — stable.** First committed ABI. KSUID (segmentio
 wire-compatible) and UUIDv7 (RFC 9562) surfaces are both
-feature-complete, tested, and locked at `libchronoid.so.0`. SemVer
+feature-complete, tested, and locked at `libchronoid.so.1`. SemVer
 applies in full from 1.0.0 forward: additions bump the minor;
 removals or signature changes require a SONAME bump
-(`libchronoid.so.0` → `libchronoid.so.1`) and a new major version.
+(`libchronoid.so.1` → `libchronoid.so.2`) and a new major version.
 Distros, language bindings, and downstream consumers can pin
 against `libchronoid >= 1.0.0` and rely on the documented contract.
 
@@ -31,7 +31,7 @@ guarantees for KSUID. The rename reflects an enlarged scope: a
 single-format port grows into a multi-format toolkit. The KSUID public
 API (types, constants, functions) is unchanged byte-for-byte at the
 ABI level; only header path (`<chronoid/ksuid.h>` instead of
-`<libksuid/ksuid.h>`) and library/SONAME (`libchronoid.so.0` instead
+`<libksuid/ksuid.h>`) and library/SONAME (`libchronoid.so.1` instead
 of `libksuid.so.1`) move.
 
 ## Goals

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('libchronoid', 'c',
-  version : '1.0.1',
+  version : '1.0.2',
   license : 'LGPL-3.0-or-later AND MIT',
   meson_version : '>=1.1.0',
   default_options : [
@@ -342,7 +342,7 @@ chronoid_lib = both_libraries('chronoid', core_sources,
   # soversion tracks semver major: a major bump means a binary-
   # incompatible ABI break and the SONAME flips with it. 1.0 is the
   # first stable ABI commitment.
-  soversion           : '0',
+  soversion           : '1',
   install             : true,
 )
 

--- a/tests/test_smoke.c
+++ b/tests/test_smoke.c
@@ -96,8 +96,8 @@ test_version_macros_are_consistent (void)
    * these four asserts in the same commit. */
   ASSERT_EQ_INT (CHRONOID_VERSION_MAJOR, 1);
   ASSERT_EQ_INT (CHRONOID_VERSION_MINOR, 0);
-  ASSERT_EQ_INT (CHRONOID_VERSION_PATCH, 1);
-  ASSERT_EQ_STR (CHRONOID_VERSION_STRING, "1.0.1");
+  ASSERT_EQ_INT (CHRONOID_VERSION_PATCH, 2);
+  ASSERT_EQ_STR (CHRONOID_VERSION_STRING, "1.0.2");
 
   /* The composite CHRONOID_VERSION must equal the documented
    * (MAJOR << 16) | (MINOR << 8) | PATCH layout for `#if


### PR DESCRIPTION
## Summary

- Bump the 1.0 branch project version to 1.0.2.
- Set the shared-library `soversion` to `1` so the 1.0 branch emits `libchronoid.so.1` / `libchronoid.1.dylib`.
- Update README, changelog, and version smoke-test expectations.

## Validation

- `meson setup build --wipe`
- `meson compile -C build`
- `meson test -C build` (`22/22 OK`)
- Verified macOS output: `build/libchronoid.1.dylib` with install name `@rpath/libchronoid.1.dylib`.
