### PR TITLE
build: reduce release artifact size

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -131,19 +131,64 @@ jobs:
         if: runner.os == 'Linux' && matrix.compiler == 'gcc'
         continue-on-error: true
         run: |
-          rm -rf build-rel
+          rm -rf build-rel build-rel-o3
+          meson setup build-rel-o3 --buildtype=release \
+            -Doptimization=3 -Dcompact_release=false
+          meson compile -C build-rel-o3
           meson setup build-rel --buildtype=release
           meson compile -C build-rel
-          strip --strip-unneeded build-rel/libchronoid.so.* 2>/dev/null || true
+
+          mapfile -t control_shared < <(find build-rel-o3 -maxdepth 1 -type f \
+            -name 'libchronoid.so.*' -print)
+          mapfile -t compact_shared < <(find build-rel -maxdepth 1 -type f \
+            -name 'libchronoid.so.*' -print)
+          if [ "${#control_shared[@]}" -ne 1 ] \
+              || [ "${#compact_shared[@]}" -ne 1 ]; then
+            echo "Expected one versioned shared library per build." >&2
+            exit 1
+          fi
+
+          strip --strip-unneeded "${control_shared[0]}"
+          strip --strip-unneeded "${compact_shared[0]}"
+
           {
-            echo '## Footprint (stripped release build) — ${{ matrix.os }}'
+            echo '## Footprint — ${{ matrix.os }} / GCC / x86_64'
             echo ''
-            echo '| Artifact | Bytes |'
-            echo '|---|---:|'
-            for f in build-rel/libchronoid.so.* build-rel/libchronoid.a build-rel/chronoid-gen; do
-              [ -e "$f" ] && printf '| %s | %s |\n' "$(basename "$f")" "$(stat -c '%s' "$f")"
+            echo 'Shared libraries are stripped with `strip --strip-unneeded`;'
+            echo 'the static archive and CLI are measured as built.'
+            echo ''
+            echo '| Artifact | O3 control | Compact O2 | Delta | Reduction |'
+            echo '|---|---:|---:|---:|---:|'
+            failed=0
+            for spec in \
+                "shared:${control_shared[0]}:${compact_shared[0]}" \
+                'static:build-rel-o3/libchronoid.a:build-rel/libchronoid.a' \
+                'chronoid-gen:build-rel-o3/chronoid-gen:build-rel/chronoid-gen'; do
+              IFS=: read -r label control_path compact_path <<< "$spec"
+              if [ ! -f "$control_path" ] || [ ! -f "$compact_path" ]; then
+                echo "Missing footprint artifact for $label." >&2
+                exit 1
+              fi
+              control_bytes=$(stat -c '%s' "$control_path")
+              compact_bytes=$(stat -c '%s' "$compact_path")
+              case "$control_bytes:$compact_bytes" in
+                *[!0-9:]*|'':*|*:'')
+                  echo "Invalid footprint size for $label." >&2
+                  exit 1
+                  ;;
+              esac
+              delta=$((compact_bytes - control_bytes))
+              reduction=$(awk -v c="$control_bytes" -v n="$compact_bytes" \
+                'BEGIN { printf "%.1f%%", 100 * (c - n) / c }')
+              printf '| %s | %s | %s | %+d | %s |\n' \
+                "$label" "$control_bytes" "$compact_bytes" "$delta" "$reduction"
+              if [ "$compact_bytes" -ge "$control_bytes" ]; then
+                echo "Compact release did not shrink $label." >&2
+                failed=1
+              fi
             done
           } >> "$GITHUB_STEP_SUMMARY"
+          exit "$failed"
 
       - name: Publish results
         if: always()

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -99,7 +99,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call tools\activate-msvc.cmd
           set CC=${{ matrix.cc }}
           meson setup builddir
 
@@ -111,7 +111,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call tools\activate-msvc.cmd
           set CC=${{ matrix.cc }}
           meson compile -C builddir
 
@@ -123,7 +123,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call tools\activate-msvc.cmd
           set CC=${{ matrix.cc }}
           meson test -C builddir --print-errorlogs
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -52,8 +52,8 @@ jobs:
           # clang-cl lane: catches the SSSE3 / AVX2 target-feature
           # gate that real cl.exe gets for free but Clang's
           # per-feature target model does not (issue #12). LLVM
-          # ships preinstalled on windows-latest as part of VS2022
-          # and vcvars64.bat puts clang-cl on PATH.
+          # ships preinstalled with Visual Studio on windows-latest,
+          # and activate-msvc.cmd puts clang-cl on PATH.
           - os: windows-latest
             compiler: clang-cl
             cc: clang-cl
@@ -88,7 +88,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call tools\activate-msvc.cmd
           set CC=${{ matrix.cc }}
           meson setup builddir
 
@@ -100,7 +100,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call tools\activate-msvc.cmd
           set CC=${{ matrix.cc }}
           meson compile -C builddir
 
@@ -112,7 +112,7 @@ jobs:
         if: runner.os == 'Windows'
         shell: cmd
         run: |
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          call tools\activate-msvc.cmd
           set CC=${{ matrix.cc }}
           meson test -C builddir --print-errorlogs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,12 @@ every binary-incompatible change, and the major version bumps with it.
 
 ### Fixed (build)
 
+- Windows CI now discovers the latest installed Visual Studio C++ toolchain
+  with `vswhere` instead of hard-coding the VS 2022 Enterprise path. This
+  restores the MSVC lane after `windows-latest` moved to the VS 2026 image and
+  keeps both MSVC and clang-cl setup independent of the installed year and
+  edition.
+
 - `meson.build` SSSE3 hex-encode kernel and AVX2 batch kernel
   discriminator switched from `cc.get_argument_syntax() == 'msvc'` to
   `cc.get_id() == 'msvc'`. The previous predicate was true for both

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ every binary-incompatible change, and the major version bumps with it.
 
 ## [Unreleased]
 
+### Changed (build)
+
+- Release builds now compile production targets at optimization level 2 by
+  default. On GCC 16.2.1 x86_64 this reduces the stripped shared library from
+  43,168 to 39,072 bytes (-9.5%), the as-built static archive from 56,142 to
+  52,358 bytes (-6.7%), and the as-built CLI from 37,312 to 33,328 bytes
+  (-10.7%) relative to an otherwise identical O3 build. Size optimization was
+  smaller but roughly halved KSUID CLI throughput, while LTO enlarged the
+  static archive more than threefold, so O2 is the size/performance compromise.
+  Pass `-Dcompact_release=false` to remove the per-target override and honor
+  the caller's global optimization setting. Public API, ABI, wire formats,
+  SIMD dispatch, and runtime dependencies are unchanged.
+
 ### Fixed (build)
 
 - `meson.build` SSSE3 hex-encode kernel and AVX2 batch kernel

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ of `libksuid.so.1`) move.
   - Per-thread ChaCha20 CSPRNG keyed from the OS source, reseeded
     every 1 MiB / hour / fork / clock-skew event.
 - **Small footprint**: no heap allocations on the hot path; no
-  third-party runtime dependencies. Stripped library is ~18 KB.
+  third-party runtime dependencies. The stripped x86_64 library is ~39 KB.
 
 ## Licensing
 
@@ -91,16 +91,24 @@ meson compile -C build-release
 strip --strip-unneeded build-release/libchronoid.so.*
 ```
 
+Release builds use Meson optimization level 2 by default. This keeps the
+installed artifacts compact without the substantial KSUID throughput loss
+observed with size optimization. To honor Meson's or the caller's global
+release optimization level instead, configure with
+`-Dcompact_release=false` (Meson's standard release default is level 3).
+
 ## Footprint
 
-A release build on x86_64 produces (post-`strip --strip-unneeded`,
-1.1.0 with UUIDv7 and the shared hex codec linked in):
+A GCC 16.2.1 release build on x86_64 produces the following paired result.
+The shared library is measured after `strip --strip-unneeded`; the static
+archive and CLI are measured as built. Both columns use the same compiler and
+linker invocation, with only `compact_release` changed:
 
-| Artifact              | Bytes  |
-| :-------------------- | -----: |
-| libchronoid.so.1.1.0  | 39 072 |
-| libchronoid.a         | 53 862 |
-| chronoid-gen (CLI)    | 31 136 |
+| Artifact              | Compact O2 | O3 control | Reduction |
+| :-------------------- | ---------: | ---------: | --------: |
+| libchronoid.so.1.1.0  |     39 072 |     43 168 |      9.5% |
+| libchronoid.a         |     52 358 |     56 142 |      6.7% |
+| chronoid-gen (CLI)    |     33 328 |     37 312 |     10.7% |
 
 The bulk-encode AVX2 kernel from `chronoid/ksuid/encode_avx2.c` accounts for
 roughly 8 KB of the shared-library size, and the UUIDv7 hex AVX2

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,17 @@ project('libchronoid', 'c',
 cc = meson.get_compiler('c')
 pkg = import('pkgconfig')
 
+# Meson's release build type selects optimization level 3. GCC and Clang
+# expand several of our fixed-trip-count codec loops aggressively at that
+# level, increasing all three installed artifacts without a measurable CLI
+# throughput benefit. Keep the public release recipe compact by overriding
+# production targets to level 2. Setting -Dcompact_release=false removes the
+# target override and honors the caller's global optimization choice.
+compact_release_options = []
+if get_option('compact_release') and get_option('buildtype') == 'release'
+  compact_release_options = ['optimization=2']
+endif
+
 # Hardening / portability flags applied to all our TUs. Compiler-
 # specific defaults split between gcc/clang and MSVC: visibility
 # control + POSIX feature macros only mean anything on the GCC-style
@@ -291,6 +302,7 @@ if have_hex_ssse3
     'chronoid/uuidv7/hex_ssse3.c',
     include_directories : inc,
     c_args              : ssse3_arg != '' ? [ssse3_arg] : [],
+    override_options    : compact_release_options,
     pic                 : true,
     install             : false,
   )
@@ -305,6 +317,7 @@ if have_avx2_batch
     'chronoid/ksuid/encode_avx2.c',
     include_directories : inc,
     c_args              : [avx2_arg],
+    override_options    : compact_release_options,
     pic                 : true,
     install             : false,
   )
@@ -328,6 +341,7 @@ if have_hex_avx2
     'chronoid/uuidv7/hex_avx2.c',
     include_directories : inc,
     c_args              : [avx2_arg],
+    override_options    : compact_release_options,
     pic                 : true,
     install             : false,
   )
@@ -338,6 +352,7 @@ chronoid_lib = both_libraries('chronoid', core_sources,
   include_directories : inc,
   dependencies        : extra_link_deps,
   link_whole          : hex_ssse3_lib_dep + avx2_lib_dep + hex_avx2_lib_dep,
+  override_options    : compact_release_options,
   version             : meson.project_version(),
   # soversion tracks semver major: a major bump means a binary-
   # incompatible ABI break and the SONAME flips with it. 1.0 is the
@@ -371,6 +386,7 @@ if get_option('cli')
     'examples/chronoid-gen.c',
     include_directories : inc,
     link_with : chronoid_lib.get_static_lib(),
+    override_options : compact_release_options,
     install : true,
   )
 endif

--- a/meson.options
+++ b/meson.options
@@ -2,6 +2,8 @@ option('tests', type : 'boolean', value : true,
        description : 'Build the unit test suite')
 option('cli', type : 'boolean', value : true,
        description : 'Build the chronoid-gen CLI tool')
+option('compact_release', type : 'boolean', value : true,
+       description : 'Use optimization level 2 for smaller release artifacts; disable to honor the global release optimization level')
 option('simd', type : 'combo', choices : ['auto', 'none'], value : 'auto',
        description : 'Enable SIMD/NEON acceleration (auto-detected per host arch)')
 option('avx2_batch', type : 'feature', value : 'auto',

--- a/tools/activate-msvc.cmd
+++ b/tools/activate-msvc.cmd
@@ -1,0 +1,18 @@
+@echo off
+rem Locate the newest Visual Studio installation that has the x64 C++
+rem toolchain. GitHub's windows-latest image can move between VS releases,
+rem so workflows must not hard-code a year or edition in this path.
+set "VSWHERE=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe"
+if not exist "%VSWHERE%" (
+  echo ERROR: vswhere.exe was not found at "%VSWHERE%". 1>&2
+  exit /b 1
+)
+
+set "CHRONOID_VS_INSTALL="
+for /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath`) do set "CHRONOID_VS_INSTALL=%%i"
+if not defined CHRONOID_VS_INSTALL (
+  echo ERROR: no Visual Studio installation with the x64 C++ toolchain was found. 1>&2
+  exit /b 1
+)
+
+call "%CHRONOID_VS_INSTALL%\VC\Auxiliary\Build\vcvars64.bat"


### PR DESCRIPTION
## Summary

- compile production release targets at Meson optimization level 2 by default
- provide `-Dcompact_release=false` to honor the caller-selected global optimization
- compare compact O2 artifacts against an explicit O3 control in the main footprint workflow
- document the measurement convention and updated footprint

## Size impact

Measured on x86_64 with GCC 16.2.1. Shared libraries are stripped with `strip --strip-unneeded`; static archives and the CLI are measured as built.

| Artifact | O3 control | Compact O2 | Reduction |
|---|---:|---:|---:|
| shared library | 43,168 B | 39,072 B | 9.5% |
| static archive | 56,142 B | 52,358 B | 6.7% |
| chronoid-gen | 37,312 B | 33,328 B | 10.7% |

`-Os` was smaller but roughly doubled KSUID CLI time, while LTO enlarged the static archive more than threefold. O2 retained throughput in the local paired benchmark.

## Validation

- GCC 16.2.1 and Clang 22.1.8 full suites: 23/23 each
- forced scalar on GCC and Clang: 23/23 each
- GCC and Clang `no-avx2`, `no-ssse3`, and `simd=none`: 23/23 each
- clang-tidy: 17 library sources, 0 user-code diagnostics
- release O2, O3 opt-out, debug, debugoptimized, minsize, and explicit O1 flags verified
- exported symbols, SONAME, and runtime dependencies unchanged

Native MSVC, macOS, and ARM coverage is delegated to the existing CI matrix.